### PR TITLE
Add "progress" to template options for podcast episodes

### DIFF
--- a/src/episode.ts
+++ b/src/episode.ts
@@ -1,5 +1,5 @@
 import { CurrentlyPlayingTrack, Episode } from "./types";
-import { millisToMinutesAndSeconds } from "./utils";
+import { millisToMinutesAndSeconds, millisToSeconds } from "./utils";
 
 export function isEpisode(data: CurrentlyPlayingTrack) {
 	return data.item.type === "episode";
@@ -26,6 +26,9 @@ export function getEpisodeMessage(
 ) {
 	if (!isEpisode(data)) throw new Error("Not an episode.");
 	const episode = data.item as Episode;
+	const progressInMilliseconds = data.progress_ms.toFixed(0);
+	const progressInSeconds = millisToSeconds(data.progress_ms);
+	const progressInMinutesAndSeconds = millisToMinutesAndSeconds(data.progress_ms);
 
 	return template
 		.replace(/{{ episode_name }}|{{episode_name}}/g, episode.name)
@@ -80,6 +83,18 @@ export function getEpisodeMessage(
 		.replace(
 			/{{ total_episodes }}|{{total_episodes}}/g,
 			episode.show.total_episodes.toString()
+		)
+		.replace(
+			/{{ progress_ms }}|{{progress_ms}}/g,
+			progressInMilliseconds
+		)
+		.replace(
+			/{{ progress_sec }}|{{progress_sec}}/g,
+			progressInSeconds
+		)
+		.replace(
+			/{{ progress_min_sec }}|{{progress_min_sec}}/g,
+			progressInMinutesAndSeconds
 		)
 		.replace(
 			/{{ timestamp }}|{{timestamp}}/g,

--- a/src/settingsTab.ts
+++ b/src/settingsTab.ts
@@ -129,6 +129,9 @@ export default class SettingsTab extends PluginSettingTab {
 			.createEl("li", { text: "{{ show_description }}" })
 			.createEl("li", { text: "{{ show_link }}" })
 			.createEl("li", { text: "{{ total_episodes }}" })
+			.createEl("li", { text: "{{ progress_ms }}" })
+			.createEl("li", { text: "{{ progress_sec }}" })
+			.createEl("li", { text: "{{ progress_min_sec }}" })
 			.createEl("li", { text: "{{ timestamp }}" });
 
 		new Setting(containerEl)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,4 +17,6 @@ export function millisToMinutesAndSeconds(millis: number) {
 	return minutes + "m:" + (seconds < 10 ? "0" : "") + seconds + "s";
 }
 
-
+export function millisToSeconds(millis: number) {
+	return (millis / 1000).toFixed(0);
+}


### PR DESCRIPTION
Exposes the progress_ms field from the currently playing track in the following forms:
- **milliseconds** (default progress type)
- **seconds** (to be used to link directly to the episode's progress)
- **minutes and seconds** (more readable for note taking purposes)