### PR TITLE
feat: implemented artist endpoint, added genres

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "spotify-link",
   "name": "Spotify Link",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "minAppVersion": "0.15.0",
   "description": "Include the song you're currently listening to in your note.",
   "author": "Studio Webux",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "spotify-link",
-  "version": "1.5.0",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "spotify-link",
-      "version": "1.5.0",
+      "version": "1.5.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^16.11.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spotify-link",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "Include the song you're currently listening to in your Obsidian (https://obsidian.md) note",
   "main": "main.js",
   "scripts": {

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,6 +1,7 @@
 import { RequestUrlResponse, requestUrl } from "obsidian";
 import {
   AccessTokenResponse,
+  Artist,
   AuthorizationCodeResponse,
   CurrentlyPlayingTrack,
   Me,
@@ -175,6 +176,33 @@ export async function getMe(
   }
 
   return json as Me;
+}
+
+export async function getArtist(
+  clientId: string,
+  clientSecret: string,
+  artistId: string,
+): Promise<Artist> {
+  const token = await getAccessToken(clientId, clientSecret);
+
+  try {
+    const response: RequestUrlResponse = await requestUrl({
+      url: `${SPOTIFY_API_BASE_ADDRESS}/artists/${artistId}`,
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    const { json } = response;
+    if (response.status !== 200) {
+      throw new Error(json?.error?.message || response.status);
+    }
+    const artist: Artist | null = json;
+    if (!artist) throw new Error("Unable to get the artist.");
+    return artist;
+  } catch (e) {
+    throw new Error("Unable to get the artist.");
+  }
 }
 
 export async function getSpotifyUrl(

--- a/src/main.ts
+++ b/src/main.ts
@@ -141,7 +141,12 @@ export default class SpotifyLinkPlugin extends Plugin {
       ) {
         template_index = 0;
       }
-      content = `${processCurrentlyPlayingTrack(track, await this.loadOrGetTemplate(this.settings.templates[template_index]))}\n\n`;
+      content = `${await processCurrentlyPlayingTrack(
+        this.settings.spotifyClientId,
+        this.settings.spotifyClientSecret,
+        track,
+        await this.loadOrGetTemplate(this.settings.templates[template_index]),
+      )}\n\n`;
     }
 
     const filename = `${normalizePath(

--- a/src/settingsTab.ts
+++ b/src/settingsTab.ts
@@ -111,7 +111,10 @@ export default class SettingsTab extends PluginSettingTab {
       .createEl("li", { text: "{{ artists }}" })
       .createEl("li", { text: "{{ song_name }}" })
       .createEl("li", { text: "{{ song_link }}" })
-      .createEl("li", { text: "{{ timestamp }}" });
+      .createEl("li", { text: "{{ timestamp }}" })
+      .createEl("li", { text: "{{ genres }}" })
+      .createEl("li", { text: "{{ genres_array }}" })
+      .createEl("li", { text: "{{ genres_hashtag }}" });
 
     divDoc.createEl("p", { text: "Available variables (podcast):" });
     divDoc
@@ -136,7 +139,10 @@ export default class SettingsTab extends PluginSettingTab {
       .createEl("li", { text: "{{ progress_ms }}" })
       .createEl("li", { text: "{{ progress_sec }}" })
       .createEl("li", { text: "{{ progress_min_sec }}" })
-      .createEl("li", { text: "{{ timestamp }}" });
+      .createEl("li", { text: "{{ timestamp }}" })
+      .createEl("li", { text: "{{ genres }}" })
+      .createEl("li", { text: "{{ genres_array }}" })
+      .createEl("li", { text: "{{ genres_hashtag }}" });
 
     divDoc.createEl("p", { text: "Template Selection:" });
     divDoc.createEl("p", {

--- a/src/settingsTab.ts
+++ b/src/settingsTab.ts
@@ -114,7 +114,11 @@ export default class SettingsTab extends PluginSettingTab {
       .createEl("li", { text: "{{ timestamp }}" })
       .createEl("li", { text: "{{ genres }}" })
       .createEl("li", { text: "{{ genres_array }}" })
-      .createEl("li", { text: "{{ genres_hashtag }}" });
+      .createEl("li", { text: "{{ genres_hashtag }}" })
+      .createEl("li", { text: "{{ followers }}" })
+      .createEl("li", { text: "{{ artist_image }}" })
+      .createEl("li", { text: "{{ popularity }}" })
+      .createEl("li", { text: "{{ artist_names }}" });
 
     divDoc.createEl("p", { text: "Available variables (podcast):" });
     divDoc

--- a/src/track.ts
+++ b/src/track.ts
@@ -98,5 +98,31 @@ export function getTrackMessage(
       )
         .flat(Infinity)
         .join(" "),
+    )
+    .replace(
+      /{{ followers }}|{{followers}}/g,
+      artists.length > 1
+        ? artists
+            ?.map((artist) => `${artist.name}: ${artist.followers.total}`)
+            .join(", ")
+        : artists[0].followers.total.toString(),
+    )
+    .replace(
+      /{{ popularity }}|{{popularity}}/g,
+      artists.length > 1
+        ? artists
+            ?.map((artist) => `${artist.name}: ${artist.popularity}`)
+            .join(", ")
+        : artists[0].popularity.toString(),
+    )
+    .replace(
+      /{{ artist_image }}|{{artist_image}}/g,
+      artists
+        ?.map((artist) => `![${artist.name}](${artist.images[0].url})`)
+        .join(", "),
+    )
+    .replace(
+      /{{ artist_name }}|{{artist_name}}/g,
+      artists?.map((artist) => artist.name).join(", "),
     );
 }

--- a/src/track.ts
+++ b/src/track.ts
@@ -1,4 +1,4 @@
-import { CurrentlyPlayingTrack, Track, TrackType } from "./types";
+import { Artist, CurrentlyPlayingTrack, Track, TrackType } from "./types";
 import { millisToMinutesAndSeconds } from "./utils";
 
 export function getTrackType(data: CurrentlyPlayingTrack): TrackType {
@@ -24,7 +24,11 @@ export function getTrackMessageTimestamp(data: CurrentlyPlayingTrack) {
   ).toFixed(0)}%)](${url})`;
 }
 
-export function getTrackMessage(data: CurrentlyPlayingTrack, template: string) {
+export function getTrackMessage(
+  data: CurrentlyPlayingTrack,
+  artists: Artist[],
+  template: string,
+) {
   if (!isTrack(data)) throw new Error("Not a track.");
   const track = data.item as Track;
 
@@ -68,5 +72,31 @@ export function getTrackMessage(data: CurrentlyPlayingTrack, template: string) {
     .replace(
       /{{ timestamp }}|{{timestamp}}/g,
       `${new Date().toDateString()} - ${new Date().toLocaleTimeString()}`,
+    )
+    .replace(
+      /{{ genres }}|{{genres}}/g,
+      Array.from(new Set(artists?.map((artist) => artist.genres)))
+        .flat(Infinity)
+        .join(", "),
+    )
+    .replace(
+      /{{ genres_array }}|{{genres_array}}/g,
+      Array.from(
+        new Set(artists?.map((artist) => artist.genres?.map((g) => `"${g}"`))),
+      )
+        .flat(Infinity)
+        .join(", "),
+    )
+    .replace(
+      /{{ genres_hashtag }}|{{genres_hashtag}}/g,
+      Array.from(
+        new Set(
+          artists?.map((artist) =>
+            artist.genres?.map((g) => `#${g.replace(/ /g, "_")}`),
+          ),
+        ),
+      )
+        .flat(Infinity)
+        .join(" "),
     );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -260,3 +260,27 @@ export type Me = {
 };
 
 export type TrackType = "track" | "episode" | "ad" | "unknown";
+
+export type Artist = {
+  external_urls: {
+    spotify: string;
+  };
+  followers: {
+    href: string;
+    total: number;
+  };
+  genres: string[];
+  href: string;
+  id: string;
+  images: [
+    {
+      url: string;
+      height: number;
+      width: number;
+    },
+  ];
+  name: string;
+  popularity: number;
+  type: "artist";
+  uri: string;
+};

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -37,7 +37,7 @@ export async function handleTemplateEditor(
     const track = await getCurrentlyPlayingTrack(clientId, clientSecret);
     if (editor) {
       editor.replaceSelection(
-        `${processCurrentlyPlayingTrack(track, template)}\n\n`,
+        `${await processCurrentlyPlayingTrack(clientId, clientSecret, track, template)}\n\n`,
       );
     }
   } catch (e) {


### PR DESCRIPTION
- Added artist api endpoint
- Added 3 new templates for the genres
- bump 1.6.0
- added artist_name, popularity, followers, artist_image, genres, genres_array, genres_hashtag
- if only one artist if defined it prints a unique value, otherwise it prefix the artist name followed by the value