### PR TITLE
feat: added new API call, first pass, not much tested

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 <h2>Obsidian.md - Spotify Plugin</h2>
 
 <p>Obsidian.md Plugin to include the song or podcast you're currently listening to in your note.</p>
+<p>Fetch daily history of played tracks.</p>
 
 <p align="center">
   <a href="https://github.com/studiowebux/obsidian-spotify-link/issues">Report Bug</a>
@@ -16,9 +17,10 @@
 ## About
 
 - **Spotify Account Integration**: Users can connect their Spotify accounts using the official Spotify API. This enables the plugin to access their **_current playing information_**.
-- **Song Insertion Shortcut**: With a simple snippet or shortcut, users can add the currently playing song from their Spotify account into the cursor position of their document. This feature simplifies the task of connecting music and creative thoughts.
+- **Song/Podcast Insertion Shortcut**: With a simple snippet or shortcut, users can add the currently playing song from their Spotify account into the cursor position of their document. This feature simplifies the task of connecting music and creative thoughts.
 - **Custom Template**: Create your template to add the currently playing song in your notes.
-- **Supports**: Songs and podcasts
+- **Supports**: Songs and podcasts.
+- **Fetch all played tracks for the day**: Works only for the current day, fetch tracks from the beginning of the day.
 
 ---
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
 	"id": "spotify-link",
 	"name": "Spotify Link",
-	"version": "1.9.0",
+	"version": "1.10.0",
 	"minAppVersion": "0.15.0",
-	"description": "Include the song you're currently listening to in your note.",
+	"description": "Include the song or podcast you're currently listening to in your note.",
 	"author": "Studio Webux",
 	"authorUrl": "https://studiowebux.com",
 	"isDesktopOnly": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "spotify-link",
-	"version": "1.9.0",
+	"version": "1.10.0",
 	"description": "Include the song you're currently listening to in your Obsidian (https://obsidian.md) note",
 	"main": "main.js",
 	"scripts": {

--- a/src/api.ts
+++ b/src/api.ts
@@ -281,7 +281,7 @@ export async function getRecentlyPlayedTracks(
 		if (!recentlyPlayed) {
 			recentlyPlayed = json;
 		} else {
-			recentlyPlayed.items.push(...json.items);
+			recentlyPlayed.items.unshift(...json.items);
 		}
 
 		if (json?.next) {

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,18 +1,21 @@
 import { RequestUrlResponse, requestUrl } from "obsidian";
 import {
-  AccessTokenResponse,
-  Artist,
-  AuthorizationCodeResponse,
-  CurrentlyPlayingTrack,
-  Me,
-  RefreshTokenResponse,
-  SpotifyAuthCallback,
+	AccessTokenResponse,
+	Artist,
+	AuthorizationCodeResponse,
+	CurrentlyPlayingTrack,
+	Me,
+	RecentlyPlayed,
+	RefreshTokenResponse,
+	SpotifyAuthCallback,
+	Track,
 } from "./types";
 import { prepareData } from "./utils";
 import { processCurrentlyPlayingTrackInput } from "./output";
 
 export const SPOTIFY_API_BASE_ADDRESS = "https://api.spotify.com/v1";
 export const REDIRECT_URI = "obsidian://spotify-auth/";
+const LIMIT = 20;
 
 ///
 /// AUTHENTICATION FLOW
@@ -20,101 +23,101 @@ export const REDIRECT_URI = "obsidian://spotify-auth/";
 
 // Step 1
 export function generateLoginUrl(
-  clientId: string,
-  state: string,
-  scope: string,
-  redirectUri: string,
+	clientId: string,
+	state: string,
+	scope: string,
+	redirectUri: string,
 ): string {
-  const q = `response_type=code&client_id=${clientId}&scope=${scope}&redirect_uri=${redirectUri}&state=${state}`;
-  return `https://accounts.spotify.com/authorize?${q}`;
+	const q = `response_type=code&client_id=${clientId}&scope=${scope}&redirect_uri=${redirectUri}&state=${state}`;
+	return `https://accounts.spotify.com/authorize?${q}`;
 }
 
 // Step 2
 export async function handleCallback(
-  params: SpotifyAuthCallback,
-  clientId: string,
-  clientSecret: string,
-  state: string,
+	params: SpotifyAuthCallback,
+	clientId: string,
+	clientSecret: string,
+	state: string,
 ): Promise<boolean> {
-  if (params.state !== state) throw new Error("Invalid state");
-  if (params.error) throw new Error(params.error);
-  if (!params.code) throw new Error("Missing Code");
+	if (params.state !== state) throw new Error("Invalid state");
+	if (params.error) throw new Error(params.error);
+	if (!params.code) throw new Error("Missing Code");
 
-  const response: AccessTokenResponse = await requestAccessToken(
-    clientId,
-    clientSecret,
-    params.code,
-    REDIRECT_URI,
-  );
-  setAccessToken(response.access_token);
-  setRefreshToken(response.refresh_token);
-  setExpiration(response.expires_in);
-  return true;
+	const response: AccessTokenResponse = await requestAccessToken(
+		clientId,
+		clientSecret,
+		params.code,
+		REDIRECT_URI,
+	);
+	setAccessToken(response.access_token);
+	setRefreshToken(response.refresh_token);
+	setExpiration(response.expires_in);
+	return true;
 }
 
 // Step 3
 async function requestAccessToken(
-  clientId: string,
-  clientSecret: string,
-  code: string,
-  redirect_uri: string,
+	clientId: string,
+	clientSecret: string,
+	code: string,
+	redirect_uri: string,
 ): Promise<AuthorizationCodeResponse> {
-  const data = {
-    code: code,
-    redirect_uri: redirect_uri,
-    grant_type: "authorization_code",
-  };
-  return await requestUrl({
-    url: "https://accounts.spotify.com/api/token",
-    method: "POST",
-    headers: {
-      "Content-Type": "application/x-www-form-urlencoded",
-      Authorization: `Basic ${btoa(clientId + ":" + clientSecret)}`,
-    },
-    body: prepareData(data),
-  }).then((res) => res.json);
+	const data = {
+		code: code,
+		redirect_uri: redirect_uri,
+		grant_type: "authorization_code",
+	};
+	return await requestUrl({
+		url: "https://accounts.spotify.com/api/token",
+		method: "POST",
+		headers: {
+			"Content-Type": "application/x-www-form-urlencoded",
+			Authorization: `Basic ${btoa(clientId + ":" + clientSecret)}`,
+		},
+		body: prepareData(data),
+	}).then((res) => res.json);
 }
 
 // Step 4
 export function setAccessToken(accessToken: string): void {
-  window.localStorage.setItem("access_token", accessToken);
+	window.localStorage.setItem("access_token", accessToken);
 }
 export function setRefreshToken(refreshToken: string): void {
-  window.localStorage.setItem("refresh_token", refreshToken);
+	window.localStorage.setItem("refresh_token", refreshToken);
 }
 export function setExpiration(expiresIn: number): void {
-  window.localStorage.setItem(
-    "expires_in",
-    (new Date().getTime() + expiresIn * 1000).toString(),
-  );
+	window.localStorage.setItem(
+		"expires_in",
+		(new Date().getTime() + expiresIn * 1000).toString(),
+	);
 }
 
 // Step 5
 export async function requestRefreshToken(
-  clientId: string,
-  clientSecret: string,
+	clientId: string,
+	clientSecret: string,
 ): Promise<string> {
-  const refreshToken = getRefreshToken();
-  const data = {
-    client_id: clientId,
-    refresh_token: refreshToken,
-    grant_type: "refresh_token",
-  };
-  const response: RefreshTokenResponse = await requestUrl({
-    url: "https://accounts.spotify.com/api/token",
-    method: "POST",
-    headers: {
-      "Content-Type": "application/x-www-form-urlencoded",
-      Authorization: `Basic ${btoa(clientId + ":" + clientSecret)}`,
-    },
-    body: prepareData(data),
-  }).then((res) => res.json);
+	const refreshToken = getRefreshToken();
+	const data = {
+		client_id: clientId,
+		refresh_token: refreshToken,
+		grant_type: "refresh_token",
+	};
+	const response: RefreshTokenResponse = await requestUrl({
+		url: "https://accounts.spotify.com/api/token",
+		method: "POST",
+		headers: {
+			"Content-Type": "application/x-www-form-urlencoded",
+			Authorization: `Basic ${btoa(clientId + ":" + clientSecret)}`,
+		},
+		body: prepareData(data),
+	}).then((res) => res.json);
 
-  setAccessToken(response.access_token);
-  setRefreshToken(response.refresh_token || refreshToken);
-  setExpiration(response.expires_in);
+	setAccessToken(response.access_token);
+	setRefreshToken(response.refresh_token || refreshToken);
+	setExpiration(response.expires_in);
 
-  return response.access_token;
+	return response.access_token;
 }
 
 ///
@@ -122,95 +125,95 @@ export async function requestRefreshToken(
 ///
 
 export async function getCurrentlyPlayingTrack(
-  clientId: string,
-  clientSecret: string,
+	clientId: string,
+	clientSecret: string,
 ): Promise<CurrentlyPlayingTrack> {
-  const token = await getAccessToken(clientId, clientSecret);
+	const token = await getAccessToken(clientId, clientSecret);
 
-  try {
-    const response: RequestUrlResponse = await requestUrl({
-      url: `${SPOTIFY_API_BASE_ADDRESS}/me/player/currently-playing?additional_types=track,episode`,
-      method: "GET",
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    });
-    const { json } = response;
-    if (response.status !== 200) {
-      throw new Error(json?.error?.message || response.status);
-    }
+	try {
+		const response: RequestUrlResponse = await requestUrl({
+			url: `${SPOTIFY_API_BASE_ADDRESS}/me/player/currently-playing?additional_types=track,episode`,
+			method: "GET",
+			headers: {
+				Authorization: `Bearer ${token}`,
+			},
+		});
+		const { json } = response;
+		if (response.status !== 200) {
+			throw new Error(json?.error?.message || response.status);
+		}
 
-    const currentlyPlayingTrack: CurrentlyPlayingTrack | null = json;
-    if (!currentlyPlayingTrack)
-      throw new Error("Unable to get the currently playing track.");
-    return currentlyPlayingTrack;
-  } catch (e) {
-    throw new Error("Unable to get the currently playing track.");
-  }
+		const currentlyPlayingTrack: CurrentlyPlayingTrack | null = json;
+		if (!currentlyPlayingTrack)
+			throw new Error("Unable to get the currently playing track.");
+		return currentlyPlayingTrack;
+	} catch (e) {
+		throw new Error("Unable to get the currently playing track.");
+	}
 }
 
 export async function getCurrentlyPlayingTrackAsString(
-  clientId: string,
-  clientSecret: string,
+	clientId: string,
+	clientSecret: string,
 ): Promise<string> {
-  const track = await getCurrentlyPlayingTrack(clientId, clientSecret);
-  return processCurrentlyPlayingTrackInput(track);
+	const track = await getCurrentlyPlayingTrack(clientId, clientSecret);
+	return processCurrentlyPlayingTrackInput(track);
 }
 
 export async function getMe(
-  clientId: string,
-  clientSecret: string,
+	clientId: string,
+	clientSecret: string,
 ): Promise<Me> {
-  const token = await getAccessToken(clientId, clientSecret);
+	const token = await getAccessToken(clientId, clientSecret);
 
-  const response: RequestUrlResponse = await requestUrl({
-    url: `${SPOTIFY_API_BASE_ADDRESS}/me`,
-    method: "GET",
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-  });
-  const { json } = response;
-  if (response.status !== 200) {
-    throw new Error(json?.error?.message || response.status);
-  }
+	const response: RequestUrlResponse = await requestUrl({
+		url: `${SPOTIFY_API_BASE_ADDRESS}/me`,
+		method: "GET",
+		headers: {
+			Authorization: `Bearer ${token}`,
+		},
+	});
+	const { json } = response;
+	if (response.status !== 200) {
+		throw new Error(json?.error?.message || response.status);
+	}
 
-  return json as Me;
+	return json as Me;
 }
 
 export async function getArtist(
-  clientId: string,
-  clientSecret: string,
-  artistId: string,
+	clientId: string,
+	clientSecret: string,
+	artistId: string,
 ): Promise<Artist> {
-  const token = await getAccessToken(clientId, clientSecret);
+	const token = await getAccessToken(clientId, clientSecret);
 
-  try {
-    const response: RequestUrlResponse = await requestUrl({
-      url: `${SPOTIFY_API_BASE_ADDRESS}/artists/${artistId}`,
-      method: "GET",
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    });
-    const { json } = response;
-    if (response.status !== 200) {
-      throw new Error(json?.error?.message || response.status);
-    }
-    const artist: Artist | null = json;
-    if (!artist) throw new Error("Unable to get the artist.");
-    return artist;
-  } catch (e) {
-    throw new Error("Unable to get the artist.");
-  }
+	try {
+		const response: RequestUrlResponse = await requestUrl({
+			url: `${SPOTIFY_API_BASE_ADDRESS}/artists/${artistId}`,
+			method: "GET",
+			headers: {
+				Authorization: `Bearer ${token}`,
+			},
+		});
+		const { json } = response;
+		if (response.status !== 200) {
+			throw new Error(json?.error?.message || response.status);
+		}
+		const artist: Artist | null = json;
+		if (!artist) throw new Error("Unable to get the artist.");
+		return artist;
+	} catch (e) {
+		throw new Error("Unable to get the artist.");
+	}
 }
 
 export async function getSpotifyUrl(
-  clientId: string,
-  clientSecret: string,
+	clientId: string,
+	clientSecret: string,
 ): Promise<string> {
-  const me = await getMe(clientId, clientSecret);
-  return me.external_urls.spotify;
+	const me = await getMe(clientId, clientSecret);
+	return me.external_urls.spotify;
 }
 
 ///
@@ -218,29 +221,80 @@ export async function getSpotifyUrl(
 ///
 
 function getExpiration(): number {
-  const expiration = window.localStorage.getItem("expires_in");
-  if (!expiration)
-    throw new Error(
-      "Something went wrong, please manually log back to spotify.",
-    );
+	const expiration = window.localStorage.getItem("expires_in");
+	if (!expiration)
+		throw new Error(
+			"Something went wrong, please manually log back to spotify.",
+		);
 
-  return parseInt(expiration);
+	return parseInt(expiration);
 }
 
 async function getAccessToken(
-  clientId: string,
-  clientSecret: string,
+	clientId: string,
+	clientSecret: string,
 ): Promise<string> {
-  const token = window.localStorage.getItem("access_token");
-  if (!token) throw new Error("You are not connected to Spotify.");
+	const token = window.localStorage.getItem("access_token");
+	if (!token) throw new Error("You are not connected to Spotify.");
 
-  if (new Date().getTime() <= getExpiration()) return token;
+	if (new Date().getTime() <= getExpiration()) return token;
 
-  return await requestRefreshToken(clientId, clientSecret);
+	return await requestRefreshToken(clientId, clientSecret);
 }
 
 function getRefreshToken(): string {
-  const token = window.localStorage.getItem("refresh_token");
-  if (!token) throw new Error("You are not connected to Spotify.");
-  return token;
+	const token = window.localStorage.getItem("refresh_token");
+	if (!token) throw new Error("You are not connected to Spotify.");
+	return token;
+}
+
+/**
+ * Get last 24H
+ */
+export async function getRecentlyPlayedTracks(
+	clientId: string,
+	clientSecret: string,
+	url: string | null = null,
+	recentlyPlayed: RecentlyPlayed | null = null,
+): Promise<RecentlyPlayed | null> {
+	const token = await getAccessToken(clientId, clientSecret);
+
+	try {
+		const date = new Date();
+		date.setHours(0, 0, 0, 0);
+		const beginningOfDayEpochTime = date.getTime();
+
+		const response: RequestUrlResponse = await requestUrl({
+			url:
+				url ||
+				`${SPOTIFY_API_BASE_ADDRESS}/me/player/recently-played?limit=${LIMIT}&after=${beginningOfDayEpochTime}`,
+			method: "GET",
+			headers: {
+				Authorization: `Bearer ${token}`,
+			},
+		});
+		const { json } = response;
+
+		if (response.status !== 200) {
+			throw new Error(json?.error?.message || response.status);
+		}
+		if (!recentlyPlayed) {
+			recentlyPlayed = json;
+		} else {
+			recentlyPlayed.items.push(...json.items);
+		}
+
+		if (json?.next) {
+			return getRecentlyPlayedTracks(
+				clientId,
+				clientSecret,
+				json.next,
+				recentlyPlayed,
+			);
+		}
+		if (!json) throw new Error("Unable to get recently played tracks.");
+		return recentlyPlayed;
+	} catch (e) {
+		throw new Error("Unable to get recently played tracks.");
+	}
 }

--- a/src/default.ts
+++ b/src/default.ts
@@ -30,6 +30,11 @@ export const DEFAULT_SETTINGS: SpotifyLinkSettings = {
 			enabled: true,
 			id: "create-file-for-currently-playing-track",
 		},
+		{
+			name: "Create file for recently played tracks using template",
+			enabled: true,
+			id: "create-file-for-recently-played-tracks-using-template",
+		},
 	],
 	defaultDestination: "",
 	overwrite: false,

--- a/src/default.ts
+++ b/src/default.ts
@@ -1,37 +1,37 @@
 import { SpotifyLinkSettings } from "./types";
 
 export const DEFAULT_SETTINGS: SpotifyLinkSettings = {
-  spotifyClientId: "",
-  spotifyClientSecret: "",
-  spotifyScopes: "user-read-currently-playing",
-  spotifyState: "it-can-be-anything",
-  templates: [
-    "**Song Name:** {{ song_name }}\n**Song URL:** {{ song_link }}\n**Album Name:** {{ album }}\n**Album Release Date:** {{ album_release }}\n**Album URL:** {{ album_link }}\n**Cover:** {{ album_cover_medium }}\n**Cover URL:** {{ album_cover_link_medium }}\n**Artists:** {{ artists }}\n**Added at:** *{{ timestamp }}*",
-    "**Episode Name:** {{ episode_name }}\n**Description:** {{ description }}\n**Added at:** *{{ timestamp }}*",
-  ],
-  menu: [
-    {
-      name: "Create file for currently playing episode using template",
-      enabled: true,
-      id: "create-file-for-currently-playing-episode-using-template",
-    },
-    {
-      name: "Create file for currently playing episode",
-      enabled: true,
-      id: "create-file-for-currently-playing-episode",
-    },
-    {
-      name: "Create file for currently playing track using template",
-      enabled: true,
-      id: "create-file-for-currently-playing-track-using-template",
-    },
-    {
-      name: "Create file for currently playing track",
-      enabled: true,
-      id: "create-file-for-currently-playing-track",
-    },
-  ],
-  defaultDestination: "",
-  overwrite: false,
-  autoOpen: false,
+	spotifyClientId: "",
+	spotifyClientSecret: "",
+	spotifyScopes: "user-read-currently-playing user-read-recently-played",
+	spotifyState: "it-can-be-anything",
+	templates: [
+		"**Song Name:** {{ song_name }}\n**Song URL:** {{ song_link }}\n**Album Name:** {{ album }}\n**Album Release Date:** {{ album_release }}\n**Album URL:** {{ album_link }}\n**Cover:** {{ album_cover_medium }}\n**Cover URL:** {{ album_cover_link_medium }}\n**Artists:** {{ artists }}\n**Added at:** *{{ timestamp }}*",
+		"**Episode Name:** {{ episode_name }}\n**Description:** {{ description }}\n**Added at:** *{{ timestamp }}*",
+	],
+	menu: [
+		{
+			name: "Create file for currently playing episode using template",
+			enabled: true,
+			id: "create-file-for-currently-playing-episode-using-template",
+		},
+		{
+			name: "Create file for currently playing episode",
+			enabled: true,
+			id: "create-file-for-currently-playing-episode",
+		},
+		{
+			name: "Create file for currently playing track using template",
+			enabled: true,
+			id: "create-file-for-currently-playing-track-using-template",
+		},
+		{
+			name: "Create file for currently playing track",
+			enabled: true,
+			id: "create-file-for-currently-playing-track",
+		},
+	],
+	defaultDestination: "",
+	overwrite: false,
+	autoOpen: false,
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,18 +1,19 @@
 import {
-  Editor,
-  Menu,
-  MenuItem,
-  Notice,
-  Plugin,
-  TFile,
-  type Vault,
-  addIcon,
-  normalizePath,
+	Editor,
+	Menu,
+	MenuItem,
+	Notice,
+	Plugin,
+	TFile,
+	type Vault,
+	addIcon,
+	normalizePath,
 } from "obsidian";
 import {
-  SpotifyLinkSettings,
-  SpotifyAuthCallback,
-  CurrentlyPlayingTrack,
+	SpotifyLinkSettings,
+	SpotifyAuthCallback,
+	CurrentlyPlayingTrack,
+	RecentlyPlayed,
 } from "./types";
 import { getSpotifyUrl, handleCallback, requestRefreshToken } from "./api";
 import SettingsTab from "./settingsTab";
@@ -20,372 +21,430 @@ import { handleEditor, handleTemplateEditor } from "./ui";
 import { onLogin, onAutoLogin } from "./events";
 import { DEFAULT_SETTINGS } from "./default";
 import {
-  getCurrentlyPlayingTrack,
-  getCurrentlyPlayingTrackAsString,
+	getCurrentlyPlayingTrack,
+	getCurrentlyPlayingTrackAsString,
+	getRecentlyPlayedTracks,
 } from "./api";
-import { processCurrentlyPlayingTrack } from "./output";
+import {
+	processCurrentlyPlayingTrack,
+	processRecentlyPlayedTracks,
+} from "./output";
 import { isPath } from "./utils";
 
 export default class SpotifyLinkPlugin extends Plugin {
-  settings: SpotifyLinkSettings;
+	settings: SpotifyLinkSettings;
 
-  // States
-  spotifyConnected = false;
-  spotifyUrl = "";
-  statusBar: HTMLElement;
+	// States
+	spotifyConnected = false;
+	spotifyUrl = "";
+	statusBar: HTMLElement;
 
-  async loadOrGetTemplate(input: string): Promise<string> {
-    try {
-      if (!input) return "";
-      const exists = await this.app.vault.adapter.exists(input, true);
-      if (exists) {
-        return this.app.vault.adapter.read(input);
-      } else {
-        // Retry adding the .md file extension automatically.
-        const exists_with_md = await this.app.vault.adapter.exists(
-          input + ".md",
-          true,
-        );
-        if (exists_with_md) {
-          return this.app.vault.adapter.read(input + ".md");
-        }
-      }
+	async loadOrGetTemplate(input: string): Promise<string> {
+		try {
+			if (!input) return "";
+			const exists = await this.app.vault.adapter.exists(input, true);
+			if (exists) {
+				return this.app.vault.adapter.read(input);
+			} else {
+				// Retry adding the .md file extension automatically.
+				const exists_with_md = await this.app.vault.adapter.exists(
+					input + ".md",
+					true,
+				);
+				if (exists_with_md) {
+					return this.app.vault.adapter.read(input + ".md");
+				}
+			}
 
-      if (isPath(input)) {
-        new Notice(
-          "[WARN] Spotify Link Plugin: The provided template looks like a path, if so, the file hasn't been found.",
-          10000,
-        );
-      }
+			if (isPath(input)) {
+				new Notice(
+					"[WARN] Spotify Link Plugin: The provided template looks like a path, if so, the file hasn't been found.",
+					10000,
+				);
+			}
 
-      return input; // This is the inline template.
-    } catch (e) {
-      new Notice("[ERROR] Spotify Link Plugin: " + e.message, 10000);
-      return "";
-    }
-  }
+			return input; // This is the inline template.
+		} catch (e) {
+			new Notice("[ERROR] Spotify Link Plugin: " + e.message, 10000);
+			return "";
+		}
+	}
 
-  async saveSettings() {
-    await this.saveData(this.settings);
-  }
+	async saveSettings() {
+		await this.saveData(this.settings);
+	}
 
-  async loadSettings() {
-    this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
-  }
+	async loadSettings() {
+		this.settings = Object.assign(
+			{},
+			DEFAULT_SETTINGS,
+			await this.loadData(),
+		);
+	}
 
-  async autoOpen(filename: string) {
-    if (this.settings.autoOpen === true) {
-      try {
-        await this.app.workspace
-          .getLeaf()
-          .openFile(this.app.vault.getAbstractFileByPath(filename) as TFile);
-      } catch (e) {
-        new Notice("[ERROR] Spotify Link Plugin: " + e.message, 10000);
-      }
-    }
-  }
+	async autoOpen(filename: string) {
+		if (this.settings.autoOpen === true) {
+			try {
+				await this.app.workspace
+					.getLeaf()
+					.openFile(
+						this.app.vault.getAbstractFileByPath(filename) as TFile,
+					);
+			} catch (e) {
+				new Notice("[ERROR] Spotify Link Plugin: " + e.message, 10000);
+			}
+		}
+	}
 
-  async createFolder(vault: Vault, folder: string) {
-    try {
-      await vault.createFolder(folder);
-    } catch (e) {
-      if (e.message !== "Folder already exists.") {
-        new Notice("[ERROR] Spotify Link Plugin: " + e.message, 10000);
-      }
-    }
-  }
+	async createFolder(vault: Vault, folder: string) {
+		try {
+			await vault.createFolder(folder);
+		} catch (e) {
+			if (e.message !== "Folder already exists.") {
+				new Notice("[ERROR] Spotify Link Plugin: " + e.message, 10000);
+			}
+		}
+	}
 
-  async overwrite(filename: string, content: string, exists: boolean) {
-    if (this.settings.overwrite === true) {
-      try {
-        await this.app.vault.modify(
-          this.app.vault.getAbstractFileByPath(filename) as TFile,
-          content,
-        );
-        if (exists) {
-          new Notice("Spotify Link Plugin: track or episode overwritten.");
-        }
-      } catch (e) {
-        new Notice("[ERROR] Spotify Link Plugin: " + e.message, 10000);
-      }
-    }
-  }
+	async overwrite(filename: string, content: string, exists: boolean) {
+		if (this.settings.overwrite === true) {
+			try {
+				await this.app.vault.modify(
+					this.app.vault.getAbstractFileByPath(filename) as TFile,
+					content,
+				);
+				if (exists) {
+					new Notice(
+						"Spotify Link Plugin: track or episode overwritten.",
+					);
+				}
+			} catch (e) {
+				new Notice("[ERROR] Spotify Link Plugin: " + e.message, 10000);
+			}
+		}
+	}
 
-  async createFile(parent: string, id: string) {
-    let content = "";
-    let track: CurrentlyPlayingTrack | string | null = null;
-    let template_index = -1;
+	async createFile(parent: string, id: string) {
+		let content = "";
+		let track: CurrentlyPlayingTrack | RecentlyPlayed | string | null =
+			null;
+		let template_index = -1;
 
-    if (
-      id === "create-file-for-currently-playing-episode" ||
-      id === "create-file-for-currently-playing-track"
-    ) {
-      track = await getCurrentlyPlayingTrackAsString(
-        this.settings.spotifyClientId,
-        this.settings.spotifyClientSecret,
-      );
-      content =
-        `> ${track}` +
-        `\n> ${new Date().toDateString()} - ${new Date().toLocaleTimeString()}` +
-        `\n\n`;
-    } else {
-      track = await getCurrentlyPlayingTrack(
-        this.settings.spotifyClientId,
-        this.settings.spotifyClientSecret,
-      );
+		if (
+			id === "create-file-for-currently-playing-episode" ||
+			id === "create-file-for-currently-playing-track"
+		) {
+			track = await getCurrentlyPlayingTrackAsString(
+				this.settings.spotifyClientId,
+				this.settings.spotifyClientSecret,
+			);
+			content =
+				`> ${track}` +
+				`\n> ${new Date().toDateString()} - ${new Date().toLocaleTimeString()}` +
+				`\n\n`;
+		} else if (
+			id === "create-file-for-recently-played-tracks-using-template"
+		) {
+			template_index = 2;
 
-      if (id === "create-file-for-currently-playing-episode-using-template") {
-        template_index = 1;
-      } else if (
-        id === "create-file-for-currently-playing-track-using-template"
-      ) {
-        template_index = 0;
-      }
-      content = `${await processCurrentlyPlayingTrack(
-        this.settings.spotifyClientId,
-        this.settings.spotifyClientSecret,
-        track,
-        await this.loadOrGetTemplate(this.settings.templates[template_index]),
-      )}\n\n`;
-    }
+			const tracks = await getRecentlyPlayedTracks(
+				this.settings.spotifyClientId,
+				this.settings.spotifyClientSecret,
+			);
 
-    const filename = `${normalizePath(
-      `/${parent}/${(track as CurrentlyPlayingTrack)?.item?.name ?? new Date().toISOString()}`,
-    ).replace(/[:|.]/g, "_")}.md`;
+			content = `${await processRecentlyPlayedTracks(
+				this.settings.spotifyClientId,
+				this.settings.spotifyClientSecret,
+				tracks,
+				await this.loadOrGetTemplate(
+					this.settings.templates[template_index],
+				),
+			)}\n\n`;
+		} else {
+			track = await getCurrentlyPlayingTrack(
+				this.settings.spotifyClientId,
+				this.settings.spotifyClientSecret,
+			);
 
-    const exists = await this.app.vault.adapter.exists(filename, true);
-    const folder = filename.substring(0, filename.lastIndexOf("/"));
-    try {
-      await this.createFolder(this.app.vault, folder);
-      await this.app.vault.create(filename, content);
-      await this.autoOpen(filename);
-    } catch (e) {
-      await this.overwrite(filename, content, exists);
-      // Auto open the file even if there is an error.
-      // Probably an already exists as the others should be handle correctly.
-      await this.autoOpen(filename);
-      new Notice("[ERROR] Spotify Link Plugin: " + e.message, 10000);
-    }
-  }
+			if (
+				id ===
+				"create-file-for-currently-playing-episode-using-template"
+			) {
+				template_index = 1;
+			} else if (
+				id === "create-file-for-currently-playing-track-using-template"
+			) {
+				template_index = 0;
+			}
+			content = `${await processCurrentlyPlayingTrack(
+				this.settings.spotifyClientId,
+				this.settings.spotifyClientSecret,
+				track,
+				await this.loadOrGetTemplate(
+					this.settings.templates[template_index],
+				),
+			)}\n\n`;
+		}
 
-  async onload() {
-    //
-    // SETTINGS
-    //
-    await this.loadSettings();
-    this.addSettingTab(new SettingsTab(this.app, this));
+		const filename = `${normalizePath(
+			`/${parent}/${(track as CurrentlyPlayingTrack)?.item?.name ?? new Date().toISOString()}`,
+		).replace(/[:|.]/g, "_")}.md`;
 
-    //
-    // BUTTON TO SIGN IN
-    //
-    addIcon(
-      "spotify",
-      '<path fill="currentColor" d="M 52.021502,2.019 C 24.520376,2.019 2.019,24.520376 2.019,52.021502 2.019,79.517624 24.520376,102.019 52.021502,102.019 79.517624,102.019 102.019,79.517624 102.019,52.021502 102.019,24.520376 79.767861,2.019 52.021502,2.019 Z m 22.996847,72.248636 c -0.995946,1.496422 -2.74761,2.001902 -4.254041,1.005956 -11.756168,-7.256894 -26.50518,-8.758321 -44.006806,-4.759522 -1.741655,0.510485 -3.243081,-0.740703 -3.743557,-2.247134 -0.50548,-1.751665 0.745709,-3.243081 2.25214,-3.748562 18.993043,-4.254041 35.498724,-2.497372 48.496071,5.50523 1.751664,0.745709 2.001902,2.742606 1.256193,4.244032 z m 6.005706,-13.74806 c -1.256194,1.746659 -3.503328,2.497372 -5.259997,1.246183 -13.497823,-8.237826 -33.992293,-10.750212 -49.742255,-5.745458 -1.991893,0.50548 -4.254042,-0.500475 -4.749512,-2.492368 -0.505481,-2.011911 0.500475,-4.26405 2.497372,-4.764526 18.247335,-5.49522 40.753716,-2.742605 56.248436,6.761424 1.501426,0.745708 2.25214,3.24308 1.005956,4.994745 z m 0.49547,-14.008308 C 65.519325,37.017248 38.768912,36.016297 23.514421,40.775819 a 4.6944597,4.6944597 0 0 1 -5.745459,-3.002853 4.689455,4.689455 0 0 1 2.997848,-5.760472 c 17.751865,-5.249988 47.004655,-4.254042 65.507232,6.761423 2.247135,1.246184 2.997848,4.249037 1.74666,6.496172 -1.251189,1.751664 -4.249037,2.492367 -6.501177,1.241179 z" style="stroke-width:5.00475" />',
-    );
-    this.addRibbonIcon("spotify", "Connect Spotify", () => {
-      onLogin(
-        this.settings.spotifyClientId,
-        this.settings.spotifyState,
-        this.settings.spotifyScopes,
-      );
-    });
+		const exists = await this.app.vault.adapter.exists(filename, true);
+		const folder = filename.substring(0, filename.lastIndexOf("/"));
+		try {
+			await this.createFolder(this.app.vault, folder);
+			await this.app.vault.create(filename, content);
+			await this.autoOpen(filename);
+		} catch (e) {
+			await this.overwrite(filename, content, exists);
+			// Auto open the file even if there is an error.
+			// Probably an already exists as the others should be handle correctly.
+			await this.autoOpen(filename);
+			new Notice("[ERROR] Spotify Link Plugin: " + e.message, 10000);
+		}
+	}
 
-    //
-    // STATUS BAR
-    //
-    this.statusBar = this.addStatusBarItem();
-    this.registerInterval(
-      window.setInterval(() => this.updateStatusBar(), 30000),
-    );
+	async onload() {
+		//
+		// SETTINGS
+		//
+		await this.loadSettings();
+		this.addSettingTab(new SettingsTab(this.app, this));
 
-    //
-    // HANDLE CALLBACK
-    //
-    this.registerObsidianProtocolHandler(
-      "spotify-auth",
-      async (params: SpotifyAuthCallback) => {
-        try {
-          this.spotifyConnected = await handleCallback(
-            params,
-            this.settings.spotifyClientId,
-            this.settings.spotifyClientSecret,
-            this.settings.spotifyState,
-          );
-          new Notice("Spotify Link Plugin: Connected to Spotify !", 3000);
-          this.spotifyUrl = await getSpotifyUrl(
-            this.settings.spotifyClientId,
-            this.settings.spotifyClientSecret,
-          );
-        } catch (e) {
-          new Notice("[ERROR] Spotify Link Plugin: " + e.message, 3000);
-          this.spotifyConnected = false;
-        } finally {
-          this.updateStatusBar();
-        }
-      },
-    );
+		//
+		// BUTTON TO SIGN IN
+		//
+		addIcon(
+			"spotify",
+			'<path fill="currentColor" d="M 52.021502,2.019 C 24.520376,2.019 2.019,24.520376 2.019,52.021502 2.019,79.517624 24.520376,102.019 52.021502,102.019 79.517624,102.019 102.019,79.517624 102.019,52.021502 102.019,24.520376 79.767861,2.019 52.021502,2.019 Z m 22.996847,72.248636 c -0.995946,1.496422 -2.74761,2.001902 -4.254041,1.005956 -11.756168,-7.256894 -26.50518,-8.758321 -44.006806,-4.759522 -1.741655,0.510485 -3.243081,-0.740703 -3.743557,-2.247134 -0.50548,-1.751665 0.745709,-3.243081 2.25214,-3.748562 18.993043,-4.254041 35.498724,-2.497372 48.496071,5.50523 1.751664,0.745709 2.001902,2.742606 1.256193,4.244032 z m 6.005706,-13.74806 c -1.256194,1.746659 -3.503328,2.497372 -5.259997,1.246183 -13.497823,-8.237826 -33.992293,-10.750212 -49.742255,-5.745458 -1.991893,0.50548 -4.254042,-0.500475 -4.749512,-2.492368 -0.505481,-2.011911 0.500475,-4.26405 2.497372,-4.764526 18.247335,-5.49522 40.753716,-2.742605 56.248436,6.761424 1.501426,0.745708 2.25214,3.24308 1.005956,4.994745 z m 0.49547,-14.008308 C 65.519325,37.017248 38.768912,36.016297 23.514421,40.775819 a 4.6944597,4.6944597 0 0 1 -5.745459,-3.002853 4.689455,4.689455 0 0 1 2.997848,-5.760472 c 17.751865,-5.249988 47.004655,-4.254042 65.507232,6.761423 2.247135,1.246184 2.997848,4.249037 1.74666,6.496172 -1.251189,1.751664 -4.249037,2.492367 -6.501177,1.241179 z" style="stroke-width:5.00475" />',
+		);
+		this.addRibbonIcon("spotify", "Connect Spotify", () => {
+			onLogin(
+				this.settings.spotifyClientId,
+				this.settings.spotifyState,
+				this.settings.spotifyScopes,
+			);
+		});
 
-    //
-    // USER INTERACTION
-    //
+		//
+		// STATUS BAR
+		//
+		this.statusBar = this.addStatusBarItem();
+		this.registerInterval(
+			window.setInterval(() => this.updateStatusBar(), 30000),
+		);
 
-    //
-    // Episode focused
-    //
+		//
+		// HANDLE CALLBACK
+		//
+		this.registerObsidianProtocolHandler(
+			"spotify-auth",
+			async (params: SpotifyAuthCallback) => {
+				try {
+					this.spotifyConnected = await handleCallback(
+						params,
+						this.settings.spotifyClientId,
+						this.settings.spotifyClientSecret,
+						this.settings.spotifyState,
+					);
+					new Notice(
+						"Spotify Link Plugin: Connected to Spotify !",
+						3000,
+					);
+					this.spotifyUrl = await getSpotifyUrl(
+						this.settings.spotifyClientId,
+						this.settings.spotifyClientSecret,
+					);
+				} catch (e) {
+					new Notice(
+						"[ERROR] Spotify Link Plugin: " + e.message,
+						3000,
+					);
+					this.spotifyConnected = false;
+				} finally {
+					this.updateStatusBar();
+				}
+			},
+		);
 
-    this.addCommand({
-      id: "append-currently-playing-episode-using-template",
-      name: "Append Spotify currently playing episode using template",
-      editorCallback: async (editor: Editor) => {
-        await handleTemplateEditor(
-          editor,
-          await this.loadOrGetTemplate(this.settings.templates[1]),
-          this.settings.spotifyClientId,
-          this.settings.spotifyClientSecret,
-        );
-      },
-    });
-    this.addCommand({
-      id: "append-currently-playing-episode",
-      name: "Append Spotify currently playing episode with timestamp",
-      editorCallback: async (editor: Editor) => {
-        await handleEditor(
-          editor,
-          this.settings.spotifyClientId,
-          this.settings.spotifyClientSecret,
-        );
-      },
-    });
-    //
-    // Song focused
-    //
-    this.addCommand({
-      id: "append-currently-playing-track-using-template",
-      name: "Append Spotify currently playing track using template",
-      editorCallback: async (editor: Editor) => {
-        await handleTemplateEditor(
-          editor,
-          await this.loadOrGetTemplate(this.settings.templates[0]),
-          this.settings.spotifyClientId,
-          this.settings.spotifyClientSecret,
-        );
-      },
-    });
-    this.addCommand({
-      id: "append-currently-playing-track",
-      name: "Append Spotify currently playing track with timestamp",
-      editorCallback: async (editor: Editor) => {
-        await handleEditor(
-          editor,
-          this.settings.spotifyClientId,
-          this.settings.spotifyClientSecret,
-        );
-      },
-    });
-    this.addCommand({
-      id: "refresh-session",
-      name: "Refresh session",
-      callback: async () => {
-        try {
-          await requestRefreshToken(
-            this.settings.spotifyClientId,
-            this.settings.spotifyClientSecret,
-          );
-          new Notice(`Spotify Link Plugin: Access Refreshed`);
-        } catch (e) {
-          new Notice(`[ERROR] Spotify Link Plugin: ${e.message}`);
-        }
-      },
-    });
+		//
+		// USER INTERACTION
+		//
 
-    this.addCommand({
-      id: "create-file-for-currently-playing-episode-using-template",
-      name: "Create file for currently playing episode using template",
-      callback: async () => {
-        await this.createFile(
-          this.settings.defaultDestination ?? "",
-          "create-file-for-currently-playing-episode-using-template",
-        );
-      },
-    });
-    this.addCommand({
-      id: "create-file-for-currently-playing-episode",
-      name: "Create file for currently playing episode",
-      callback: async () => {
-        await this.createFile(
-          this.settings.defaultDestination ?? "",
-          "create-file-for-currently-playing-episode",
-        );
-      },
-    });
-    this.addCommand({
-      id: "create-file-for-currently-playing-track-using-template",
-      name: "Create file for currently playing track using template",
-      callback: async () => {
-        await this.createFile(
-          this.settings.defaultDestination ?? "",
-          "create-file-for-currently-playing-track-using-template",
-        );
-      },
-    });
-    this.addCommand({
-      id: "create-file-for-currently-playing-track",
-      name: "Create file for currently playing track",
-      callback: async () => {
-        await this.createFile(
-          this.settings.defaultDestination ?? "",
-          "create-file-for-currently-playing-track",
-        );
-      },
-    });
+		//
+		// Episode focused
+		//
 
-    //
-    // Create new page and fill content
-    //
-    if (this.settings?.menu) {
-      for (const customMenu of this.settings.menu) {
-        if (!customMenu.enabled) return;
-        const menuCreateFile = (menu: Menu, file: TFile) => {
-          menu.addItem((item: MenuItem) => {
-            item.setTitle(customMenu.name).onClick(async () => {
-              try {
-                await this.createFile(file.path, customMenu.id);
-              } catch (e) {
-                new Notice(`[ERROR] Spotify Link Plugin: ${e.message}`);
-                return false;
-              }
-            });
-          });
-        };
-        this.registerEvent(this.app.workspace.on("file-menu", menuCreateFile));
-      }
-    } else {
-      new Notice("Your spotify link configuration might be outdated.");
-    }
+		this.addCommand({
+			id: "append-currently-playing-episode-using-template",
+			name: "Append Spotify currently playing episode using template",
+			editorCallback: async (editor: Editor) => {
+				await handleTemplateEditor(
+					editor,
+					await this.loadOrGetTemplate(this.settings.templates[1]),
+					this.settings.spotifyClientId,
+					this.settings.spotifyClientSecret,
+				);
+			},
+		});
+		this.addCommand({
+			id: "append-currently-playing-episode",
+			name: "Append Spotify currently playing episode with timestamp",
+			editorCallback: async (editor: Editor) => {
+				await handleEditor(
+					editor,
+					this.settings.spotifyClientId,
+					this.settings.spotifyClientSecret,
+				);
+			},
+		});
+		//
+		// Song focused
+		//
+		this.addCommand({
+			id: "append-currently-playing-track-using-template",
+			name: "Append Spotify currently playing track using template",
+			editorCallback: async (editor: Editor) => {
+				await handleTemplateEditor(
+					editor,
+					await this.loadOrGetTemplate(this.settings.templates[0]),
+					this.settings.spotifyClientId,
+					this.settings.spotifyClientSecret,
+				);
+			},
+		});
+		this.addCommand({
+			id: "append-currently-playing-track",
+			name: "Append Spotify currently playing track with timestamp",
+			editorCallback: async (editor: Editor) => {
+				await handleEditor(
+					editor,
+					this.settings.spotifyClientId,
+					this.settings.spotifyClientSecret,
+				);
+			},
+		});
+		this.addCommand({
+			id: "refresh-session",
+			name: "Refresh session",
+			callback: async () => {
+				try {
+					await requestRefreshToken(
+						this.settings.spotifyClientId,
+						this.settings.spotifyClientSecret,
+					);
+					new Notice(`Spotify Link Plugin: Access Refreshed`);
+				} catch (e) {
+					new Notice(`[ERROR] Spotify Link Plugin: ${e.message}`);
+				}
+			},
+		});
 
-    //
-    // Events
-    //
-    try {
-      const info = await onAutoLogin(
-        this.settings.spotifyClientId,
-        this.settings.spotifyClientSecret,
-      );
-      this.spotifyConnected = info.success;
-      this.spotifyUrl = info.spotifyUrl;
-    } catch (e) {
-      new Notice(`[ERROR] Spotify Link Plugin: ${e.message}`);
-      return false;
-    } finally {
-      this.updateStatusBar();
-    }
-  }
+		this.addCommand({
+			id: "create-file-for-currently-playing-episode-using-template",
+			name: "Create file for currently playing episode using template",
+			callback: async () => {
+				await this.createFile(
+					this.settings.defaultDestination ?? "",
+					"create-file-for-currently-playing-episode-using-template",
+				);
+			},
+		});
+		this.addCommand({
+			id: "create-file-for-currently-playing-episode",
+			name: "Create file for currently playing episode",
+			callback: async () => {
+				await this.createFile(
+					this.settings.defaultDestination ?? "",
+					"create-file-for-currently-playing-episode",
+				);
+			},
+		});
+		this.addCommand({
+			id: "create-file-for-currently-playing-track-using-template",
+			name: "Create file for currently playing track using template",
+			callback: async () => {
+				await this.createFile(
+					this.settings.defaultDestination ?? "",
+					"create-file-for-currently-playing-track-using-template",
+				);
+			},
+		});
+		this.addCommand({
+			id: "create-file-for-currently-playing-track",
+			name: "Create file for currently playing track",
+			callback: async () => {
+				await this.createFile(
+					this.settings.defaultDestination ?? "",
+					"create-file-for-currently-playing-track",
+				);
+			},
+		});
 
-  onunload() {}
+		// Recently Played tracks
+		this.addCommand({
+			id: "create-file-for-recently-played-tracks-using-template",
+			name: "Create file for recently played tracks using template",
+			callback: async () => {
+				await this.createFile(
+					this.settings.defaultDestination ?? "",
+					"create-file-for-recently-played-tracks-using-template",
+				);
+			},
+		});
 
-  updateStatusBar() {
-    this.statusBar.setText(
-      `Spotify ${!this.spotifyConnected ? "not" : ""} Connected`,
-    );
-  }
+		//
+		// Create new page and fill content
+		//
+		if (this.settings?.menu) {
+			for (const customMenu of this.settings.menu) {
+				if (!customMenu.enabled) return;
+				const menuCreateFile = (menu: Menu, file: TFile) => {
+					menu.addItem((item: MenuItem) => {
+						item.setTitle(customMenu.name).onClick(async () => {
+							try {
+								await this.createFile(file.path, customMenu.id);
+							} catch (e) {
+								new Notice(
+									`[ERROR] Spotify Link Plugin: ${e.message}`,
+								);
+								return false;
+							}
+						});
+					});
+				};
+				this.registerEvent(
+					this.app.workspace.on("file-menu", menuCreateFile),
+				);
+			}
+		} else {
+			new Notice("Your spotify link configuration might be outdated.");
+		}
+
+		//
+		// Events
+		//
+		try {
+			const info = await onAutoLogin(
+				this.settings.spotifyClientId,
+				this.settings.spotifyClientSecret,
+			);
+			this.spotifyConnected = info.success;
+			this.spotifyUrl = info.spotifyUrl;
+		} catch (e) {
+			new Notice(`[ERROR] Spotify Link Plugin: ${e.message}`);
+			return false;
+		} finally {
+			this.updateStatusBar();
+		}
+	}
+
+	onunload() {}
+
+	updateStatusBar() {
+		this.statusBar.setText(
+			`Spotify ${!this.spotifyConnected ? "not" : ""} Connected`,
+		);
+	}
 }

--- a/src/output.ts
+++ b/src/output.ts
@@ -56,7 +56,6 @@ export async function processRecentlyPlayedTracks(
 	data: RecentlyPlayed,
 	template = `'{{ song_name }}' by {{ artists }} from {{ album }} released in {{ album_release }} @ {{ played_at }}`,
 ): Promise<string> {
-	console.debug(data);
 	const messages: string[] = [];
 	if (data && data.items) {
 		for (const item of data.items) {

--- a/src/output.ts
+++ b/src/output.ts
@@ -1,50 +1,79 @@
-import { getArtist } from "./api";
+import { getArtist, getRecentlyPlayedTracks } from "./api";
 import { getEpisodeMessage, getEpisodeMessageTimestamp } from "./episode";
 import {
-  getTrackMessage,
-  getTrackMessageTimestamp,
-  getTrackType,
+	getRecentlyPlayedTrackMessage,
+	getTrackMessage,
+	getTrackMessageTimestamp,
+	getTrackType,
 } from "./track";
-import { CurrentlyPlayingTrack, Track } from "./types";
+import { CurrentlyPlayingTrack, RecentlyPlayed, Track } from "./types";
 
 export function processCurrentlyPlayingTrackInput(
-  data: CurrentlyPlayingTrack,
+	data: CurrentlyPlayingTrack,
 ): string {
-  if (data && data.is_playing) {
-    if (getTrackType(data) === "track") {
-      return getTrackMessageTimestamp(data);
-    }
-    if (getTrackType(data) === "episode") {
-      return getEpisodeMessageTimestamp(data);
-    }
+	if (data && data.is_playing) {
+		if (getTrackType(data) === "track") {
+			return getTrackMessageTimestamp(data);
+		}
+		if (getTrackType(data) === "episode") {
+			return getEpisodeMessageTimestamp(data);
+		}
 
-    throw new Error(
-      "The data received is not handle. You can request it by opening a GitHub issue and providing the track URL so that I can adjust the tool accordingly.",
-    );
-  }
-  return "No song is playing.";
+		throw new Error(
+			"The data received is not handle. You can request it by opening a GitHub issue and providing the track URL so that I can adjust the tool accordingly.",
+		);
+	}
+	return "No song is playing.";
 }
 
 export async function processCurrentlyPlayingTrack(
-  clientId: string,
-  clientSecret: string,
-  data: CurrentlyPlayingTrack,
-  template = `'{{ song_name }}' by {{ artists }} from {{ album }} released in {{ album_release }}\n{{ timestamp }}`,
+	clientId: string,
+	clientSecret: string,
+	data: CurrentlyPlayingTrack,
+	template = `'{{ song_name }}' by {{ artists }} from {{ album }} released in {{ album_release }}\n{{ timestamp }}`,
 ): Promise<string> {
-  if (data && data.is_playing) {
-    if (getTrackType(data) === "track") {
-      const artists = (data.item as Track).artists.map((artist) =>
-        getArtist(clientId, clientSecret, artist.id),
-      );
-      return getTrackMessage(data, await Promise.all(artists), template);
-    }
-    if (getTrackType(data) === "episode") {
-      return getEpisodeMessage(data, template);
-    }
+	if (data && data.is_playing) {
+		if (getTrackType(data) === "track") {
+			const artists = (data.item as Track).artists.map((artist) =>
+				getArtist(clientId, clientSecret, artist.id),
+			);
+			return getTrackMessage(data, await Promise.all(artists), template);
+		}
+		if (getTrackType(data) === "episode") {
+			return getEpisodeMessage(data, template);
+		}
 
-    throw new Error(
-      "The data received is not handle. You can request it by opening a GitHub issue and providing the track URL so that I can adjust the tool accordingly.",
-    );
-  }
-  return "No song is playing.";
+		throw new Error(
+			"The data received is not handle. You can request it by opening a GitHub issue and providing the track URL so that I can adjust the tool accordingly.",
+		);
+	}
+	return "No song is playing.";
+}
+
+export async function processRecentlyPlayedTracks(
+	clientId: string,
+	clientSecret: string,
+	data: RecentlyPlayed,
+	template = `'{{ song_name }}' by {{ artists }} from {{ album }} released in {{ album_release }} @ {{ played_at }}`,
+): Promise<string> {
+	console.debug(data);
+	const messages: string[] = [];
+	if (data && data.items) {
+		for (const item of data.items) {
+			const artists = (item.track as Track).artists.map((artist) =>
+				getArtist(clientId, clientSecret, artist.id),
+			);
+			messages.push(
+				getRecentlyPlayedTrackMessage(
+					item,
+					await Promise.all(artists),
+					template,
+				),
+			);
+		}
+
+		return messages.join("\n");
+	}
+
+	return "Nothing fetched from Spotify API.";
 }

--- a/src/settingsTab.ts
+++ b/src/settingsTab.ts
@@ -208,6 +208,22 @@ export default class SettingsTab extends PluginSettingTab {
 					}),
 			);
 		new Setting(containerEl)
+			.setName("Template for recently played tracks")
+			.setDesc(
+				"Define a custom template to print the recently played tracks or a path to your template definition",
+			)
+			.addTextArea((text) =>
+				text
+					.setPlaceholder(
+						"Example: '{{ song_name }}' by {{ artists }} from {{ album }} released in {{ album_release }}\n",
+					)
+					.setValue(this.plugin.settings.templates[2])
+					.onChange(async (value) => {
+						this.plugin.settings.templates[2] = value;
+						await this.plugin.saveSettings();
+					}),
+			);
+		new Setting(containerEl)
 			.setName("Default destination")
 			.setDesc(
 				"Destination to store track or episode when using the command palette, default at the root of your vault",

--- a/src/track.ts
+++ b/src/track.ts
@@ -1,5 +1,11 @@
 import { millisToMinutesAndSeconds, padZero } from "./utils";
-import { Artist, CurrentlyPlayingTrack, Track, TrackType } from "./types";
+import {
+	Artist,
+	CurrentlyPlayingTrack,
+	RecentlyPlayed,
+	Track,
+	TrackType,
+} from "./types";
 
 export function getTrackType(data: CurrentlyPlayingTrack): TrackType {
 	return data.currently_playing_type;
@@ -33,6 +39,203 @@ export function getTrackMessage(
 	const track = data.item as Track;
 	return template
 		.replace(/{{ song_name }}|{{song_name}}/g, track.name)
+		.replace(
+			/{{ song_link }}|{{song_link}}/g,
+			`[${track.name} - ${track.artists.map((a) => a.name).join(", ")}](${track.external_urls.spotify})`,
+		)
+		.replace(
+			/{{ artists }}|{{artist}}/g,
+			track.artists.map((a) => a.name).join(", "),
+		)
+		.replace(
+			/{{ artists_formatted(:.*?)?(:.*?)? }}|{{artists_formatted(:.*?)?(:.*?)?}}/g,
+			(_match, ...options) => {
+				const matches = options
+					.slice(0, options.length - 2)
+					.filter((m) => m !== undefined);
+
+				const prefix = matches[0]?.substring(1) || "";
+				const suffix = matches[1]?.substring(1) || "";
+				const isTag = prefix === "#";
+
+				if (isTag) {
+					return track.artists
+						.map(
+							(a) =>
+								`${prefix}${a.name?.replace(/ /g, "_")}${suffix}`,
+						)
+						.join("\n");
+				}
+
+				return track.artists
+					.map((a) => `${prefix}${a.name}${suffix}`)
+					.join("\n");
+			},
+		)
+		.replace(
+			/{{ album_release }}|{{album_release}}/g,
+			track.album.release_date,
+		)
+		.replace(
+			/{{ album_cover_large }}|{{album_cover_large}}/g,
+			`![${track.album.name}](${track.album.images[0].url})`,
+		)
+		.replace(
+			/{{ album_cover_medium }}|{{album_cover_medium}}/g,
+			`![${track.album.name}](${track.album.images[1]?.url})`,
+		)
+		.replace(
+			/{{ album_cover_small }}|{{album_cover_small}}/g,
+			`![${track.album.name}](${track.album.images[2]?.url})`,
+		)
+		.replace(
+			/{{ album_cover_link_large }}|{{album_cover_link_large}}/g,
+			`[Cover - ${track.album.name}](${track.album.images[0].url})`,
+		)
+		.replace(
+			/{{ album_cover_link_medium }}|{{album_cover_link_medium}}/g,
+			`[Cover - ${track.album.name}](${track.album.images[1]?.url})`,
+		)
+		.replace(
+			/{{ album_cover_link_small }}|{{album_cover_link_small}}/g,
+			`[Cover - ${track.album.name}](${track.album.images[2]?.url})`,
+		)
+		.replace(
+			/{{ album_link }}|{{album_link}}/g,
+			`[${track.album.name}](${track.album.external_urls.spotify})`,
+		)
+		.replace(/{{ album }}|{{album}}/g, track.album.name)
+		.replace(
+			/{{ timestamp(z?)(\(((YYYY-MM-DD)?( ?HH:mm)?)\))? }}|{{timestamp(z?)(\(((YYYY-MM-DD)?( ?HH:mm)?)\))? }}/g,
+			(_match, ...options) => {
+				const matches = options
+					.slice(0, options.length - 2)
+					.filter((m) => m !== undefined);
+
+				let timestamp = "";
+				const hasYearMonthDate = matches.includes("YYYY-MM-DD");
+				const hasHourMinutes =
+					matches.includes(" HH:mm") || matches.includes("HH:mm");
+				if (matches.includes("z")) {
+					if (hasYearMonthDate) {
+						timestamp += `${new Date().getUTCFullYear()}-${padZero(new Date().getUTCMonth() + 1)}-${padZero(new Date().getUTCDate())}`;
+					}
+					if (hasHourMinutes) {
+						if (timestamp.length > 0) {
+							timestamp += " ";
+						}
+						timestamp += `${padZero(new Date().getUTCHours())}:${padZero(new Date().getUTCMinutes())}`;
+					}
+
+					if (matches.length === 1) {
+						timestamp = `${new Date().toISOString()}`;
+					}
+				} else {
+					if (hasYearMonthDate) {
+						timestamp += `${new Date().getFullYear()}-${padZero(new Date().getMonth() + 1)}-${padZero(new Date().getDate())}`;
+					}
+					if (hasHourMinutes) {
+						if (timestamp.length > 0) {
+							timestamp += " ";
+						}
+						timestamp += `${padZero(new Date().getHours())}:${padZero(new Date().getMinutes())}`;
+					}
+
+					if (matches.length === 1) {
+						timestamp = `${new Date().toDateString()} - ${new Date().toLocaleTimeString()}`;
+					}
+				}
+
+				return timestamp;
+			},
+		)
+		.replace(
+			/{{ genres }}|{{genres}}/g,
+			Array.from(new Set(artists?.map((artist) => artist.genres)))
+				.flat(Infinity)
+				.join(", "),
+		)
+		.replace(
+			/{{ genres_array }}|{{genres_array}}/g,
+			Array.from(
+				new Set(
+					artists?.map((artist) =>
+						artist.genres?.map((g) => `"${g}"`),
+					),
+				),
+			)
+				.flat(Infinity)
+				.join(", "),
+		)
+		.replace(
+			/{{ genres_hashtag }}|{{genres_hashtag}}/g,
+			Array.from(
+				new Set(
+					artists?.map((artist) =>
+						artist.genres?.map((g) => `#${g.replace(/ /g, "_")}`),
+					),
+				),
+			)
+				.flat(Infinity)
+				.join(" "),
+		)
+		.replace(
+			/{{ followers }}|{{followers}}/g,
+			artists.length > 1
+				? artists
+						?.map(
+							(artist) =>
+								`${artist.name}: ${artist.followers.total}`,
+						)
+						.join(", ")
+				: artists[0].followers.total.toString(),
+		)
+		.replace(
+			/{{ popularity }}|{{popularity}}/g,
+			artists.length > 1
+				? artists
+						?.map(
+							(artist) => `${artist.name}: ${artist.popularity}`,
+						)
+						.join(", ")
+				: artists[0].popularity.toString(),
+		)
+		.replace(
+			/{{ artist_image }}|{{artist_image}}/g,
+			artists
+				?.map((artist) => `![${artist.name}](${artist.images[0].url})`)
+				.join(", "),
+		)
+		.replace(
+			/{{ artist_name }}|{{artist_name}}/g,
+			artists?.map((artist) => artist.name).join(", "),
+		);
+}
+
+export function getRecentlyPlayedTrackMessage(
+	data: {
+		track: Track;
+		played_at: string;
+		context: {
+			type: string;
+			href: string;
+			external_urls: {
+				spotify: string;
+			};
+			url: string;
+		};
+	},
+	artists: Artist[],
+	template: string,
+) {
+	const track = data.track as Track;
+	return template
+		.replace(/{{ song_name }}|{{song_name}}/g, track.name)
+
+		.replace(
+			/{{ played_at }}|{{played_at}}/g,
+			`${`${new Date(data.played_at).getFullYear()}-${padZero(new Date(data.played_at).getMonth() + 1)}-${padZero(new Date(data.played_at).getDate())}`} ${padZero(new Date(data.played_at).getHours())}:${padZero(new Date(data.played_at).getMinutes())}`,
+		)
 		.replace(
 			/{{ song_link }}|{{song_link}}/g,
 			`[${track.name} - ${track.artists.map((a) => a.name).join(", ")}](${track.external_urls.spotify})`,

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,285 +2,308 @@
 // Obsidian Settings
 //
 export type SpotifyLinkSettings = {
-  spotifyClientId: string;
-  spotifyClientSecret: string;
-  spotifyScopes: string;
-  spotifyState: string;
-  templates: string[];
-  menu: Array<{ name: string; enabled: boolean; id: string }>;
-  defaultDestination: string;
-  overwrite: boolean;
-  autoOpen: boolean;
+	spotifyClientId: string;
+	spotifyClientSecret: string;
+	spotifyScopes: string;
+	spotifyState: string;
+	templates: string[];
+	menu: Array<{ name: string; enabled: boolean; id: string }>;
+	defaultDestination: string;
+	overwrite: boolean;
+	autoOpen: boolean;
 };
 
 //
 // Spotify
 //
 export type Track = {
-  album: {
-    album_type: string;
-    total_tracks: number;
-    available_markets: string[];
-    external_urls: {
-      spotify: string;
-    };
-    href: string;
-    id: string;
-    images: {
-      url: string;
-      height: number;
-      width: number;
-    }[];
-    name: string;
-    release_date: string;
-    release_date_precision: string;
-    restrictions: {
-      reason: string;
-    };
-    type: string;
-    uri: string;
-    artists: [
-      {
-        external_urls: {
-          spotify: string;
-        };
-        href: string;
-        id: string;
-        name: string;
-        type: string;
-        uri: string;
-      },
-    ];
-  };
-  artists: [
-    {
-      external_urls: {
-        spotify: string;
-      };
-      followers: {
-        href: string;
-        total: number;
-      };
-      genres: string[];
-      href: string;
-      id: string;
-      images: [
-        {
-          url: string;
-          height: number;
-          width: number;
-        },
-      ];
-      name: string;
-      popularity: 0;
-      type: string;
-      uri: string;
-    },
-  ];
-  available_markets: [string];
-  disc_number: string;
-  duration_ms: string;
-  explicit: boolean;
-  external_ids: {
-    isrc: string;
-    ean: string;
-    upc: string;
-  };
-  external_urls: {
-    spotify: string;
-  };
-  href: string;
-  id: string;
-  is_playable: boolean;
-  linked_from: object;
-  restrictions: {
-    reason: string;
-  };
-  name: string;
-  popularity: number;
-  preview_url: string;
-  track_number: number;
-  type: "track";
-  uri: string;
-  is_local: boolean;
+	album: {
+		album_type: string;
+		total_tracks: number;
+		available_markets: string[];
+		external_urls: {
+			spotify: string;
+		};
+		href: string;
+		id: string;
+		images: {
+			url: string;
+			height: number;
+			width: number;
+		}[];
+		name: string;
+		release_date: string;
+		release_date_precision: string;
+		restrictions: {
+			reason: string;
+		};
+		type: string;
+		uri: string;
+		artists: [
+			{
+				external_urls: {
+					spotify: string;
+				};
+				href: string;
+				id: string;
+				name: string;
+				type: string;
+				uri: string;
+			},
+		];
+	};
+	artists: [
+		{
+			external_urls: {
+				spotify: string;
+			};
+			followers: {
+				href: string;
+				total: number;
+			};
+			genres: string[];
+			href: string;
+			id: string;
+			images: [
+				{
+					url: string;
+					height: number;
+					width: number;
+				},
+			];
+			name: string;
+			popularity: 0;
+			type: string;
+			uri: string;
+		},
+	];
+	available_markets: [string];
+	disc_number: string;
+	duration_ms: string;
+	explicit: boolean;
+	external_ids: {
+		isrc: string;
+		ean: string;
+		upc: string;
+	};
+	external_urls: {
+		spotify: string;
+	};
+	href: string;
+	id: string;
+	is_playable: boolean;
+	linked_from: object;
+	restrictions: {
+		reason: string;
+	};
+	name: string;
+	popularity: number;
+	preview_url: string;
+	track_number: number;
+	type: "track";
+	uri: string;
+	is_local: boolean;
 };
 
 export type Episode = {
-  audio_preview_url: string | null;
-  description: string;
-  html_description: string;
-  duration_ms: number;
-  explicit: boolean;
-  external_urls: {
-    spotify: string;
-  };
-  href: string;
-  id: string;
-  images: {
-    url: string;
-    height: number;
-    width: number;
-  }[];
-  is_externally_hosted: boolean;
-  is_playable: boolean;
-  languages: [string];
-  name: string;
-  release_date: string;
-  release_date_precision: "year" | "month" | "day";
-  resume_point: { fully_played: boolean; resume_position_ms: number };
-  type: "episode";
-  uri: string;
-  restriction: { reason: string };
-  show: {
-    available_markets: [string];
-    copyrights: [{ text: string; type: string }];
-    description: string;
-    html_description: string;
-    explicit: boolean;
-    external_urls: {
-      spotify: string;
-    };
-    href: string;
-    id: string;
-    images: [
-      {
-        url: string;
-        height: number;
-        width: number;
-      },
-    ];
-    is_externally_hosted: boolean;
-    languages: [string];
-    name: string;
-    publisher: string;
-    type: "show";
-    uri: string;
-    total_episodes: number;
-  };
+	audio_preview_url: string | null;
+	description: string;
+	html_description: string;
+	duration_ms: number;
+	explicit: boolean;
+	external_urls: {
+		spotify: string;
+	};
+	href: string;
+	id: string;
+	images: {
+		url: string;
+		height: number;
+		width: number;
+	}[];
+	is_externally_hosted: boolean;
+	is_playable: boolean;
+	languages: [string];
+	name: string;
+	release_date: string;
+	release_date_precision: "year" | "month" | "day";
+	resume_point: { fully_played: boolean; resume_position_ms: number };
+	type: "episode";
+	uri: string;
+	restriction: { reason: string };
+	show: {
+		available_markets: [string];
+		copyrights: [{ text: string; type: string }];
+		description: string;
+		html_description: string;
+		explicit: boolean;
+		external_urls: {
+			spotify: string;
+		};
+		href: string;
+		id: string;
+		images: [
+			{
+				url: string;
+				height: number;
+				width: number;
+			},
+		];
+		is_externally_hosted: boolean;
+		languages: [string];
+		name: string;
+		publisher: string;
+		type: "show";
+		uri: string;
+		total_episodes: number;
+	};
 };
 
 export type CurrentlyPlayingTrack = {
-  device: {
-    id: string;
-    is_active: boolean;
-    is_private_session: boolean;
-    is_restricted: boolean;
-    name: string;
-    type: string;
-    volume_percent: number;
-    supports_volume: boolean;
-  };
-  repeat_state: string;
-  shuffle_state: boolean;
-  context: {
-    type: string;
-    href: string;
-    external_urls: {
-      spotify: string;
-    };
-    uri: string;
-  };
-  timestamp: number;
-  progress_ms: number;
-  is_playing: boolean;
-  item: Track | Episode;
-  currently_playing_type: TrackType;
-  actions: {
-    interrupting_playback: boolean;
-    pausing: boolean;
-    resuming: boolean;
-    seeking: boolean;
-    skipping_next: boolean;
-    skipping_prev: boolean;
-    toggling_repeat_context: boolean;
-    toggling_shuffle: boolean;
-    toggling_repeat_track: boolean;
-    transferring_playback: boolean;
-  };
+	device: {
+		id: string;
+		is_active: boolean;
+		is_private_session: boolean;
+		is_restricted: boolean;
+		name: string;
+		type: string;
+		volume_percent: number;
+		supports_volume: boolean;
+	};
+	repeat_state: string;
+	shuffle_state: boolean;
+	context: {
+		type: string;
+		href: string;
+		external_urls: {
+			spotify: string;
+		};
+		uri: string;
+	};
+	timestamp: number;
+	progress_ms: number;
+	is_playing: boolean;
+	item: Track | Episode;
+	currently_playing_type: TrackType;
+	actions: {
+		interrupting_playback: boolean;
+		pausing: boolean;
+		resuming: boolean;
+		seeking: boolean;
+		skipping_next: boolean;
+		skipping_prev: boolean;
+		toggling_repeat_context: boolean;
+		toggling_shuffle: boolean;
+		toggling_repeat_track: boolean;
+		transferring_playback: boolean;
+	};
 };
 
 export type AccessTokenResponse = {
-  access_token: string;
-  token_type: string;
-  scope: string;
-  expires_in: number;
-  refresh_token: string;
+	access_token: string;
+	token_type: string;
+	scope: string;
+	expires_in: number;
+	refresh_token: string;
 };
 
 export type RefreshTokenResponse = {
-  access_token: string;
-  token_type: "Bearer";
-  scope: string;
-  expires_in: number;
-  refresh_token: string;
+	access_token: string;
+	token_type: "Bearer";
+	scope: string;
+	expires_in: number;
+	refresh_token: string;
 };
 
 export type AuthorizationCodeResponse = {
-  access_token: string;
-  token_type: string;
-  scope: string;
-  expires_in: number;
-  refresh_token: string;
+	access_token: string;
+	token_type: string;
+	scope: string;
+	expires_in: number;
+	refresh_token: string;
 };
 
 export type SpotifyAuthCallback = {
-  action: string;
-  error?: string;
-  code?: string;
-  state: string;
+	action: string;
+	error?: string;
+	code?: string;
+	state: string;
 };
 
 export type Me = {
-  country: string;
-  display_name: string;
-  email: string;
-  explicit_content: {
-    filter_enabled: boolean;
-    filter_locked: boolean;
-  };
-  external_urls: {
-    spotify: string;
-  };
-  followers: {
-    href: string;
-    total: number;
-  };
-  href: string;
-  id: string;
-  images: [
-    {
-      url: string;
-      height: number;
-      width: number;
-    },
-  ];
-  product: string;
-  type: string;
-  uri: string;
+	country: string;
+	display_name: string;
+	email: string;
+	explicit_content: {
+		filter_enabled: boolean;
+		filter_locked: boolean;
+	};
+	external_urls: {
+		spotify: string;
+	};
+	followers: {
+		href: string;
+		total: number;
+	};
+	href: string;
+	id: string;
+	images: [
+		{
+			url: string;
+			height: number;
+			width: number;
+		},
+	];
+	product: string;
+	type: string;
+	uri: string;
 };
 
 export type TrackType = "track" | "episode" | "ad" | "unknown";
 
 export type Artist = {
-  external_urls: {
-    spotify: string;
-  };
-  followers: {
-    href: string;
-    total: number;
-  };
-  genres: string[];
-  href: string;
-  id: string;
-  images: [
-    {
-      url: string;
-      height: number;
-      width: number;
-    },
-  ];
-  name: string;
-  popularity: number;
-  type: "artist";
-  uri: string;
+	external_urls: {
+		spotify: string;
+	};
+	followers: {
+		href: string;
+		total: number;
+	};
+	genres: string[];
+	href: string;
+	id: string;
+	images: [
+		{
+			url: string;
+			height: number;
+			width: number;
+		},
+	];
+	name: string;
+	popularity: number;
+	type: "artist";
+	uri: string;
+};
+
+export type RecentlyPlayed = {
+	limit: number;
+	next: string | null;
+
+	cursors: {
+		after: string;
+		before: string;
+	};
+
+	total: number;
+
+	items: Array<{
+		track: Track;
+		played_at: string;
+		context: {
+			type: string;
+			href: string;
+			external_urls: { spotify: string };
+			url: string;
+		};
+	}>;
 };


### PR DESCRIPTION
- Added new scope to allow fetching history
- Added new API Call to fetch track history (From the beginning of the current day)
- Added new command `create-file-for-recently-played-tracks-using-template` 
- Added new template for the recently played tracks (it uses the same as the currently played track, with only one new field `played_at` that has the date using timezone format) 
- Requires new scope and potentially updating configuration
- Default template : ``'{{ song_name }}' by {{ artists }} from {{ album }} released in {{ album_release }} @ {{ played_at }}``