### PR TITLE
30 bug file name conflict with same track title different artists

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "spotify-link",
 	"name": "Spotify Link",
-	"version": "1.10.1",
+	"version": "1.11.0",
 	"minAppVersion": "0.15.0",
 	"description": "Include the song or podcast you're currently listening to in your note.",
 	"author": "Studio Webux",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "spotify-link",
-	"version": "1.10.1",
+	"version": "1.11.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "spotify-link",
-			"version": "1.10.1",
+			"version": "1.11.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^16.11.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "spotify-link",
-	"version": "1.10.1",
+	"version": "1.11.0",
 	"description": "Include the song you're currently listening to in your Obsidian (https://obsidian.md) note",
 	"main": "main.js",
 	"scripts": {

--- a/src/api.ts
+++ b/src/api.ts
@@ -8,7 +8,6 @@ import {
 	RecentlyPlayed,
 	RefreshTokenResponse,
 	SpotifyAuthCallback,
-	Track,
 } from "./types";
 import { prepareData } from "./utils";
 import { processCurrentlyPlayingTrackInput } from "./output";

--- a/src/default.ts
+++ b/src/default.ts
@@ -39,4 +39,5 @@ export const DEFAULT_SETTINGS: SpotifyLinkSettings = {
 	defaultDestination: "",
 	overwrite: false,
 	autoOpen: false,
+	appendArtistNames: false,
 };

--- a/src/output.ts
+++ b/src/output.ts
@@ -1,4 +1,4 @@
-import { getArtist, getRecentlyPlayedTracks } from "./api";
+import { getArtist } from "./api";
 import { getEpisodeMessage, getEpisodeMessageTimestamp } from "./episode";
 import {
 	getRecentlyPlayedTrackMessage,

--- a/src/settingsTab.ts
+++ b/src/settingsTab.ts
@@ -264,6 +264,17 @@ export default class SettingsTab extends PluginSettingTab {
 				});
 			});
 
+		new Setting(containerEl)
+			.setName("Append Artist Name(s)")
+			.setDesc("Append artist name(s) to create unique filename.")
+			.addToggle((toggle) => {
+				toggle.setValue(this.plugin.settings.appendArtistNames);
+				toggle.onChange(async (value: boolean) => {
+					this.plugin.settings.appendArtistNames = value;
+					await this.plugin.saveSettings();
+				});
+			});
+
 		containerEl.createEl("hr");
 
 		containerEl.createEl("h5", { text: "Spotify Integration (Advanced)" });

--- a/src/track.ts
+++ b/src/track.ts
@@ -1,11 +1,5 @@
 import { millisToMinutesAndSeconds, padZero } from "./utils";
-import {
-	Artist,
-	CurrentlyPlayingTrack,
-	RecentlyPlayed,
-	Track,
-	TrackType,
-} from "./types";
+import { Artist, CurrentlyPlayingTrack, Track, TrackType } from "./types";
 
 export function getTrackType(data: CurrentlyPlayingTrack): TrackType {
 	return data.currently_playing_type;

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export type SpotifyLinkSettings = {
 	defaultDestination: string;
 	overwrite: boolean;
 	autoOpen: boolean;
+	appendArtistNames: boolean;
 };
 
 //


### PR DESCRIPTION
- Added new options: `appendArtistNames`, default: false
- This option append a list of artists, separated using underscore (`_`)
- Tested only currently playing track, with one and two artists
- Tested with the option disabled

Selected this approach cause was simple and more intuitive i think