### PR TITLE
fix(getName): handle string input from suggester / currently-playing path

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -189,12 +189,39 @@ export default class SpotifyLinkPlugin extends Plugin {
 		}
 	}
 
-	async getName(track?: CurrentlyPlayingTrack | Track): Promise<string> {
+	async getName(
+		track?: CurrentlyPlayingTrack | Track | string | null,
+	): Promise<string> {
 		let name = new Date().toISOString();
 
-		// Accept either a raw Track or a CurrentlyPlayingTrack wrapper
+		// The "currently playing" branch in createFile assigns `track` to the
+		// formatted markdown string returned by getCurrentlyPlayingTrackAsString,
+		// and suggester paths can also hand us the rendered display string for
+		// the selected entry. Recover by parsing the track ID out of the
+		// embedded Spotify URL and re-fetching the underlying Track object.
+		if (typeof track === "string") {
+			const m = track.match(/open\.spotify\.com\/track\/([A-Za-z0-9]+)/);
+			if (!m) return name;
+			try {
+				track = await getTrack(
+					this.settings.spotifyClientId,
+					this.settings.spotifyClientSecret,
+					m[1],
+				);
+			} catch (e) {
+				console.error(
+					"Spotify Link Plugin: getName re-fetch failed",
+					e,
+				);
+				return name;
+			}
+		}
+
+		// Accept either a raw Track or a CurrentlyPlayingTrack wrapper.
+		// The `typeof === "object"` guard prevents the `in` operator from
+		// being applied to a primitive if a future caller slips one in.
 		const item: Track | undefined =
-			track && "item" in track
+			track && typeof track === "object" && "item" in track
 				? (track.item as Track)
 				: (track as Track | undefined);
 
@@ -461,7 +488,7 @@ export default class SpotifyLinkPlugin extends Plugin {
 		if (!content) return;
 
 		const filename = `${normalizePath(
-			`/${parent}/${await this.getName(trackForName ?? track as CurrentlyPlayingTrack)}`,
+			`/${parent}/${await this.getName(trackForName ?? track)}`,
 		).replace(/[:|.]/g, "_")}.md`;
 
 		const exists = await this.app.vault.adapter.exists(filename, true);


### PR DESCRIPTION
## Summary

`SpotifyLinkPlugin.getName` throws `TypeError: Cannot use 'in' operator to search for 'item' in <string>` whenever it receives a string instead of a `Track` / `CurrentlyPlayingTrack` object. This happens in normal use:

- The `create-file-for-currently-playing-*` branch in `createFile` assigns `track = await getCurrentlyPlayingTrackAsString(...)` (a markdown-formatted display string), then passes that same `track` to `getName` via the call site at `src/main.ts:464`.
- A suggester selection can also hand the rendered display string for the chosen entry into the same code path.

The call site casts to `CurrentlyPlayingTrack`, which silently hides the string variant declared one screen up in the same function (`let track: CurrentlyPlayingTrack | RecentlyPlayed | string | null`), so the type system never warns.

### Repro (current main)

1. Trigger any command that opens a track suggester (e.g. recently-played list).
2. Pick a track.

```
Uncaught (in promise) TypeError: Cannot use 'in' operator to search for 'item' in
  ['**Goodbye Henry. (feat. Al Green)**' by ***RAYE, Al Green*** **1m:51s** (35%)](https://open.spotify.com/track/5lBL8xRTXIDpPDJcuPL9UH)
    at SpotifyLinkPlugin.getName    (main.js:1839:34)
    at SpotifyLinkPlugin.createFile (main.js:2065:32)
    at async Object.callback        (main.js:2144:11)
```

No file is created.

## Changes

- `getName` parameter widened to `CurrentlyPlayingTrack | Track | string | null`, matching what `createFile` actually declares for `track`.
- When `getName` receives a string, the embedded `open.spotify.com/track/<id>` URL is parsed out and the underlying `Track` is re-fetched via the existing `getTrack(clientId, clientSecret, idOrUrl)` helper — so the note keeps its real `<TrackName>-<Artists>.md` filename instead of falling back to a timestamp.
- The misleading `as CurrentlyPlayingTrack` cast at the call site is dropped; the widened signature now carries the union through honestly.
- The existing `'item' in track` check is guarded with `typeof track === 'object'` so a future primitive can never trigger the same `TypeError` again.

If the URL can't be parsed (e.g. a string with no embedded Spotify track URL, or a future episode picker that doesn't go through `getName`), `getName` falls back to its original ISO-timestamp default instead of throwing — no regression for callers that already handled that fallback.

This is the same defensive pattern already used elsewhere in `createFile` (`typeof track !== "string" && "item" in track`) — just applied at the one place that was missing it.

## Verification

- `npm run build` passes locally (`tsc -noEmit -skipLibCheck && esbuild production`).
- Equivalent diff hand-applied to the bundled `main.js` of an installed 1.15.2 — the crash is gone, the recently-played suggester now creates correctly named files, and the re-fetch path produces identical output to the non-suggester flow.

## Test plan

- [ ] Run a recently-played / suggester-based command, pick a track → file gets the real `<name>-<artists>.md` filename, no console error.
- [ ] Run `create-file-for-currently-playing-track` → still works (the same string path is now recovered instead of crashing).
- [ ] Pick a track on a transient network failure → re-fetch fails, falls back to ISO-timestamp filename, no crash.